### PR TITLE
Switch to sglib namespace from vg

### DIFF
--- a/include/sglib/eades_algorithm.hpp
+++ b/include/sglib/eades_algorithm.hpp
@@ -16,7 +16,7 @@
 #include <unordered_map>
 #include <deque>
 
-namespace vg {
+namespace sglib {
 namespace algorithms {
 
 using namespace std;

--- a/include/sglib/endianness.hpp
+++ b/include/sglib/endianness.hpp
@@ -8,7 +8,7 @@
 #include <cstdlib>
 #include <type_traits>
 
-namespace vg {
+namespace sglib {
 
     /**
      * A struct namespace for methods to handle endianness in integer values.

--- a/include/sglib/hash_graph.hpp
+++ b/include/sglib/hash_graph.hpp
@@ -14,7 +14,7 @@
 #include "sglib/utility.hpp"
 #include "sglib/endianness.hpp"
 
-namespace vg {
+namespace sglib {
     
 using namespace std;
 using namespace handlegraph;

--- a/include/sglib/hash_map.hpp
+++ b/include/sglib/hash_map.hpp
@@ -87,7 +87,7 @@ struct hash<std::tuple<TT...>>
 #endif  // OVERLOAD_PAIR_HASH
 
 
-namespace vg {
+namespace sglib {
 
 // We need this second type for enable_if-based specialization
 template<typename T, typename ImplementationMatched = void>

--- a/include/sglib/is_single_stranded.hpp
+++ b/include/sglib/is_single_stranded.hpp
@@ -13,7 +13,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace vg {
+namespace sglib {
 namespace algorithms {
 
 using namespace std;

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -20,7 +20,7 @@
 #include "sglib/eades_algorithm.hpp"
 
 
-namespace vg {
+namespace sglib {
     
 using namespace std;
 using namespace handlegraph;

--- a/include/sglib/packed_structs.hpp
+++ b/include/sglib/packed_structs.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 #include <sdsl/int_vector.hpp>
 
-namespace vg {
+namespace sglib {
     
 using namespace std;
     

--- a/include/sglib/split_strand_graph.hpp
+++ b/include/sglib/split_strand_graph.hpp
@@ -10,7 +10,7 @@
 #include <handlegraph/expanding_overlay_graph.hpp>
 #include "sglib/utility.hpp"
 
-namespace vg {
+namespace sglib {
 
 using namespace std;
 using namespace handlegraph;

--- a/include/sglib/utility.hpp
+++ b/include/sglib/utility.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 
-namespace vg {
+namespace sglib {
 
 using namespace std;
 

--- a/include/sglib/wang_hash.hpp
+++ b/include/sglib/wang_hash.hpp
@@ -3,7 +3,7 @@
 
 #include <cstddef>
 
-namespace vg {
+namespace sglib {
 
 /// Thomas Wang's integer hash function. In many implementations, std::hash
 /// is identity function for integers, which leads to performance issues.

--- a/src/eades_algorithm.cpp
+++ b/src/eades_algorithm.cpp
@@ -8,7 +8,7 @@
 
 #include "sglib/eades_algorithm.hpp"
 
-namespace vg {
+namespace sglib {
 namespace algorithms {
 
 using namespace std;

--- a/src/hash_graph.cpp
+++ b/src/hash_graph.cpp
@@ -6,7 +6,7 @@
 
 #include <handlegraph/util.hpp>
 
-namespace vg {
+namespace sglib {
     
     using namespace handlegraph;
     

--- a/src/is_single_stranded.cpp
+++ b/src/is_single_stranded.cpp
@@ -1,6 +1,6 @@
 #include "sglib/is_single_stranded.hpp"
 
-namespace vg {
+namespace sglib {
 namespace algorithms {
 
 using namespace std;

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -7,7 +7,7 @@
 #include <handlegraph/util.hpp>
 #include <atomic>
 
-namespace vg {
+namespace sglib {
 
     using namespace handlegraph;
     

--- a/src/packed_structs.cpp
+++ b/src/packed_structs.cpp
@@ -5,7 +5,7 @@
 #include "sglib/packed_structs.hpp"
 
 
-namespace vg {
+namespace sglib {
     
 const double PackedVector::factor = 1.25;
 const double PackedDeque::factor = 1.25;

--- a/src/split_strand_graph.cpp
+++ b/src/split_strand_graph.cpp
@@ -8,7 +8,7 @@
 #include <handlegraph/util.hpp>
 
 
-namespace vg {
+namespace sglib {
 
 using namespace std;
 using namespace handlegraph;
@@ -50,7 +50,7 @@ using namespace handlegraph;
         
         return graph->follow_edges(get_underlying_handle(handle), go_left,
                                    [&] (const handle_t& next) {
-            return iteratee(get_handle((graph->get_id(next) << 1) + graph->get_is_reverse(next),
+            return iteratee(get_handle((graph->get_id(next) << 1) + (graph->get_is_reverse(next) != get_is_reverse(handle)),
                                        get_is_reverse(handle)));
         });
     }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,6 +1,6 @@
 #include "sglib/utility.hpp"
 
-namespace vg {
+namespace sglib {
 
 static const char complement[256] = {'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 8
                                      'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', // 16


### PR DESCRIPTION
Preventing clashes so I can switch to this library in the handle evaluation instead of the implementations that still live in VG.