### PR TITLE
Improve memory usage of path names in PackedGraph

### DIFF
--- a/include/sglib/hash_map.hpp
+++ b/include/sglib/hash_map.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "sglib/wang_hash.hpp"
+#include "sglib/packed_structs.hpp"
 
 // Comment out to use sparse_hash_map and sparse_hash_set instead of
 // dense_hash_map and dense_hash_set.
@@ -85,6 +86,19 @@ struct hash<std::tuple<TT...>>
 };
 }
 #endif  // OVERLOAD_PAIR_HASH
+
+// make a hash function for PackedVectors
+namespace std {
+    struct hash<sglib::PackedVector> {
+        size_t operator(const sglib::PackedVector& vec) {
+            size_t hash_val = 0;
+            for (size_t i = 0; i < vec.size(); ++i) {
+                hash_combine(hash_val, vec.get(i));
+            }
+            return hash_val;
+        }
+    };
+}
 
 
 namespace sglib {

--- a/include/sglib/hash_map.hpp
+++ b/include/sglib/hash_map.hpp
@@ -89,8 +89,9 @@ struct hash<std::tuple<TT...>>
 
 // make a hash function for PackedVectors
 namespace std {
+    template<>
     struct hash<sglib::PackedVector> {
-        size_t operator(const sglib::PackedVector& vec) {
+        size_t operator()(const sglib::PackedVector& vec) {
             size_t hash_val = 0;
             for (size_t i = 0; i < vec.size(); ++i) {
                 hash_combine(hash_val, vec.get(i));

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -466,6 +466,7 @@ private:
     
     /// Vector of the embedded paths in the graph
     vector<PackedPath> paths;
+    const static double PATH_RESIZE_FACTOR;
     
     ///////////////////////////////////////////////////////////////////////
     /// Convenience functions to translate between encodings in the vectors

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -321,20 +321,21 @@ private:
     /// WARNING: invalidates step_handle_t's to this path.
     void defragment_path(PackedPath& path, bool force = false);
     
-    /// Convert a path name into an integer vector, assigning new chars as necessary
+    /// Convert a path name into an integer vector, assigning new chars as necessary.
     PackedVector encode_and_assign_path_name(const string& path_name);
     
     /// Convert a path name into an integer vector using only existing char assignments
+    /// If the path name contains previously unseen characters, returns an empty vector.
     PackedVector encode_path_name(const string& path_name) const;
     
     /// Encode the path name into the internal representation and append it to the master
-    /// list of path names
+    /// list of path names.
     void append_path_name(const string& path_name);
     
-    /// Decode the internal representation of a path name and return it as a string
+    /// Decode the internal representation of a path name and return it as a string.
     string decode_path_name(const PackedPath& path) const;
     
-    /// Extract the internal representation of a path name, but do not decode it
+    /// Extract the internal representation of a path name, but do not decode it.
     PackedVector extract_encoded_path_name(const PackedPath& path) const;
     
     /// Defragment data structures when the orphaned records are this fraction of the whole.
@@ -477,7 +478,8 @@ private:
     /// Complement nucleotide encoded as [0, 4]
     inline uint64_t complement_encoded_nucleotide(const uint64_t& val) const;
     
-    /// Get the integer assignment of a char
+    /// Get the integer assignment of a char, or numeric_limits<uint64_t>::max()
+    /// if no assignment has been made
     inline uint64_t get_assignment(const char& c) const;
     /// Get the integer assignment of a char, assigning a new one if necessary
     inline uint64_t get_or_make_assignment(const char& c);
@@ -651,7 +653,13 @@ inline void PackedGraph::set_step_next(PackedPath& path, const uint64_t& step_in
 }
     
 inline uint64_t PackedGraph::get_assignment(const char& c) const {
-    return char_assignment.at(c);
+    auto it = char_assignment.find(c);
+    if (it != char_assignment.end()) {
+        return it->second;
+    }
+    else {
+        return numeric_limits<uint64_t>::max();
+    }
 }
 
 inline uint64_t PackedGraph::get_or_make_assignment(const char& c) {

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -322,7 +322,7 @@ private:
     void defragment_path(PackedPath& path, bool force = false);
     
     /// Convert a path name into an integer vector, assigning new chars as necessary
-    PackedVector encode_path_name(const string& path_name);
+    PackedVector encode_and_assign_path_name(const string& path_name);
     
     /// Convert a path name into an integer vector using only existing char assignments
     PackedVector encode_path_name(const string& path_name) const;
@@ -333,6 +333,9 @@ private:
     
     /// Decode the internal representation of a path name and return it as a string
     string decode_path_name(const PackedPath& path) const;
+    
+    /// Extract the internal representation of a path name, but do not decode it
+    PackedVector extract_encoded_path_name(const PackedPath& path) const;
     
     /// Defragment data structures when the orphaned records are this fraction of the whole.
     const static double defrag_factor;
@@ -458,7 +461,7 @@ private:
     const static size_t STEP_RECORD_SIZE;
     
     /// Map from path names to index in the paths vector.
-    string_hash_map<string, int64_t> path_id;
+    string_hash_map<PackedVector, int64_t> path_id;
     
     /// Vector of the embedded paths in the graph
     vector<PackedPath> paths;

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -319,7 +319,7 @@ private:
     /// reallocating and defragmenting it. If so, do it. Optionally, defragment even if
     /// we have not deleted many things.
     /// WARNING: invalidates step_handle_t's to this path.
-    void defragment_path(PackedPath& path, bool force = false);
+    void defragment_path(const int64_t& path_idx, bool force = false);
     
     /// Convert a path name into an integer vector, assigning new chars as necessary.
     PackedVector encode_and_assign_path_name(const string& path_name);
@@ -333,10 +333,10 @@ private:
     void append_path_name(const string& path_name);
     
     /// Decode the internal representation of a path name and return it as a string.
-    string decode_path_name(const PackedPath& path) const;
+    string decode_path_name(const int64_t& path_idx) const;
     
     /// Extract the internal representation of a path name, but do not decode it.
-    PackedVector extract_encoded_path_name(const PackedPath& path) const;
+    PackedVector extract_encoded_path_name(const int64_t& path_idx) const;
     
     /// Defragment data structures when the orphaned records are this fraction of the whole.
     const static double defrag_factor;
@@ -420,17 +420,18 @@ private:
     /// a single vector
     PackedVector path_names_iv;
     
+    /// The starting index of the path's name in path_names_iv for the path with the
+    /// same index in paths
+    PagedVector path_name_start_iv;
+    
+    /// The length of the path's name for the path with the same index in paths
+    PackedVector path_name_length_iv;
+    
     /*
      * A struct to package the data associated with a path through the graph.
      */
     struct PackedPath {
         PackedPath(bool is_circular) : is_circular(is_circular), steps_iv(NARROW_PAGE_WIDTH), links_iv(NARROW_PAGE_WIDTH) {}
-        
-        /// The starting index of the path's name in path_names_iv
-        size_t path_name_start = 0;
-        
-        /// The length of the path's name
-        size_t path_name_length = 0;
         
         /// Marks whether this path has been deleted
         bool is_deleted = false;

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -332,7 +332,7 @@ private:
     void append_path_name(const string& path_name);
     
     /// Decode the internal representation of a path name and return it as a string
-    string decode_path_name(const PackedVector& path) const;
+    string decode_path_name(const PackedPath& path) const;
     
     /// Defragment data structures when the orphaned records are this fraction of the whole.
     const static double defrag_factor;
@@ -407,8 +407,15 @@ private:
     const static size_t MEMBERSHIP_OFFSET_RECORD_SIZE;
     const static size_t MEMBERSHIP_NEXT_RECORD_SIZE;
     
-    /// All path names, concatenated in a single vector
+    /// We will reassign char values from the path names to small integers
+    hash_map<char, uint64_t> char_assignment;
+    /// The inverse mapping from integer to the char value
+    string inverse_char_assignment;
+    
+    /// All path names, encoded according to the char assignments and concatenated in
+    /// a single vector
     PackedVector path_names_iv;
+    
     /*
      * A struct to package the data associated with a path through the graph.
      */
@@ -449,11 +456,6 @@ private:
     const static size_t PATH_NEXT_OFFSET;
     
     const static size_t STEP_RECORD_SIZE;
-    
-    /// We will reassign char values form path names to integers
-    hash_map<char, uint64_t> char_assignment;
-    /// The inverse mapping from integer to the char value
-    string inverse_char_assignment;
     
     /// Map from path names to index in the paths vector.
     string_hash_map<string, int64_t> path_id;

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -466,6 +466,7 @@ private:
     
     /// Vector of the embedded paths in the graph
     vector<PackedPath> paths;
+    static const double PATH_RESIZE_FACTOR;
     
     ///////////////////////////////////////////////////////////////////////
     /// Convenience functions to translate between encodings in the vectors

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -466,7 +466,6 @@ private:
     
     /// Vector of the embedded paths in the graph
     vector<PackedPath> paths;
-    const static double PATH_RESIZE_FACTOR;
     
     ///////////////////////////////////////////////////////////////////////
     /// Convenience functions to translate between encodings in the vectors

--- a/include/sglib/packed_structs.hpp
+++ b/include/sglib/packed_structs.hpp
@@ -65,17 +65,21 @@ public:
     /// be included in the vector without reallocating. Never shrinks capacity.
     inline void reserve(const size_t& future_size);
         
-    /// Returns the number of values
+    /// Returns the number of values.
     inline size_t size() const;
         
-    /// Returns true if there are no entries and false otherwise
+    /// Returns true if there are no entries and false otherwise.
     inline bool empty() const;
 
-    /// Clears the backing vector
+    /// Clears the backing vector.
     inline void clear();
     
     /// Reports the amount of memory consumed by this object in bytes.
     size_t memory_usage() const;
+    
+    /// Returns true if the contents are identical (but not necessarily storage
+    /// parameters, such as pointer to data, capacity, bit width, etc.).
+    inline bool operator==(const PackedVector& other) const;
         
 private:
         
@@ -331,6 +335,19 @@ inline void PackedVector::clear() {
     vec.resize(0);
     vec.width(1);
     filled = 0;
+}
+    
+inline bool PackedVector::operator==(const PackedVector& other) const {
+    if (size() != other.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < size(); ++i) {
+        if (get(i) != other.get(i)) {
+            return false;
+        }
+    }
+    
+    return true;
 }
     
 /////////////////////

--- a/include/sglib/packed_structs.hpp
+++ b/include/sglib/packed_structs.hpp
@@ -35,6 +35,11 @@ public:
     PackedVector(PackedVector&& other) = default;
     /// Move assignment operator
     PackedVector& operator=(PackedVector&& other) = default;
+    
+    /// Copy constructor
+    PackedVector(const PackedVector& other) = default;
+    /// Copy assignment operator
+    PackedVector& operator=(const PackedVector& other) = default;
         
     /// Destructor
     ~PackedVector();

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1475,6 +1475,9 @@ namespace sglib {
     }
     
     path_handle_t PackedGraph::create_path_handle(const string& name, bool is_circular) {
+        if (name.empty()) {
+            throw std::runtime_error("[PackedGraph] error: cannot create paths with no name");
+        }
         
         PackedVector encoded = encode_and_assign_path_name(name);
         if (path_id.count(encoded)) {
@@ -1817,7 +1820,7 @@ namespace sglib {
         size_t name_total = 0, id_total = 0, links_total = 0, steps_total = 0, other_total = 0;
         for (const auto& path_name : names) {
             auto it = path_id.find(encode_path_name(path_name));
-            size_t path_name_mem = sizeof(it->first) + it->first.capacity() * sizeof(char);
+            size_t path_name_mem = it->first.memory_usage();
             size_t path_id_mem = sizeof(it->second);
             const auto& packed_path = paths.at(it->second);
             size_t other_mem = (sizeof(packed_path.is_deleted) + sizeof(packed_path.is_circular)

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -934,6 +934,24 @@ namespace sglib {
             
             // TODO: should I reassign the char to int mapping in case entire chars where ejected?
         }
+        
+        // consolidate the path name pointer vectors (we do this to get them to a tight allocation
+        // even if no paths have been deleted)
+        PagedVector new_path_name_start_iv(path_name_start_iv.page_width());
+        new_path_name_start_iv.resize(paths.size());
+        for (size_t i = 0; i < paths.size(); ++i) {
+            new_path_name_start_iv.set(i, path_name_start_iv.get(i));
+        }
+        path_name_start_iv = move(new_path_name_start_iv);
+        
+        PackedVector new_path_name_length_iv;
+        new_path_name_length_iv.resize(paths.size());
+        for (size_t i = 0; i < paths.size(); ++i) {
+            new_path_name_length_iv.set(i, path_name_length_iv.get(i));
+        }
+        path_name_length_iv = move(new_path_name_length_iv);
+        
+        // TODO: unless paths have been deleted, path_names_iv doesn't get a tight allocation...
     }
     
     void PackedGraph::compact_ids(const vector<handle_t>& order) {

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -51,7 +51,8 @@ namespace sglib {
         path_membership_node_iv(NARROW_PAGE_WIDTH),
         path_membership_next_iv(NARROW_PAGE_WIDTH),
         path_membership_offset_iv(NARROW_PAGE_WIDTH),
-        path_membership_id_iv(WIDE_PAGE_WIDTH) {
+        path_membership_id_iv(WIDE_PAGE_WIDTH),
+        path_name_start_iv(NARROW_PAGE_WIDTH) {
         
         // set pretty full load factors
         path_id.max_load_factor(0.5);
@@ -879,13 +880,15 @@ namespace sglib {
             
             if (paths[i].is_deleted) {
                 num_paths_deleted++;
-                path_name_length_deleted += paths[i].path_name_length;
+                path_name_length_deleted += path_name_length_iv.get(i);
                 continue;
             }
             
-            // move non-deleted paths into the front of the vector
+            // move non-deleted paths into the front of the vectors
             if (num_paths_deleted > 0) {
                 paths[i - num_paths_deleted] = std::move(paths[i]);
+                path_name_start_iv.set(i - num_paths_deleted, path_name_start_iv.get(i));
+                path_name_length_iv.set(i - num_paths_deleted, path_name_length_iv.get(i));
             }
         }
         

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -42,6 +42,8 @@ namespace sglib {
     const size_t PackedGraph::PATH_PREV_OFFSET = 0;
     const size_t PackedGraph::PATH_NEXT_OFFSET = 1;
     
+    const double PackedGraph::PATH_RESIZE_FACTOR = 1.25;
+    
     PackedGraph::PackedGraph() :
         graph_iv(NARROW_PAGE_WIDTH),
         seq_start_iv(NARROW_PAGE_WIDTH),
@@ -1499,9 +1501,8 @@ namespace sglib {
         
         // we manually handle the geometric expansion of the array so we can give it a smaller
         // constant factor on the memory
-        // TODO: magic number
         if (paths.size() == paths.capacity()) {
-            size_t new_capacity = paths.capacity() * 1.25;
+            size_t new_capacity = paths.capacity() * PATH_RESIZE_FACTOR;
             if (new_capacity == paths.capacity()) {
                 new_capacity++;
             }

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -42,8 +42,6 @@ namespace sglib {
     const size_t PackedGraph::PATH_PREV_OFFSET = 0;
     const size_t PackedGraph::PATH_NEXT_OFFSET = 1;
     
-    const double PATH_RESIZE_FACTOR = 1.25;
-    
     PackedGraph::PackedGraph() :
         graph_iv(NARROW_PAGE_WIDTH),
         seq_start_iv(NARROW_PAGE_WIDTH),
@@ -1501,8 +1499,9 @@ namespace sglib {
         
         // we manually handle the geometric expansion of the array so we can give it a smaller
         // constant factor on the memory
+        // TODO: magic number
         if (paths.size() == paths.capacity()) {
-            size_t new_capacity = paths.capacity() * PATH_RESIZE_FACTOR;
+            size_t new_capacity = paths.capacity() * 1.25;
             if (new_capacity == paths.capacity()) {
                 new_capacity++;
             }

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1257,7 +1257,13 @@ namespace sglib {
     }
     
     bool PackedGraph::has_path(const std::string& path_name) const {
-        return path_id.count(encode_path_name(path_name));
+        auto encoded = encode_path_name(path_name);
+        if (encoded.empty()) {
+            return false;
+        }
+        else {
+            return path_id.count(encoded);
+        }
     }
     
     path_handle_t PackedGraph::get_path_handle(const std::string& path_name) const {
@@ -1395,7 +1401,13 @@ namespace sglib {
         PackedVector encoded;
         encoded.resize(path_name.size());
         for (size_t i = 0; i < path_name.size(); ++i) {
-            encoded.set(i, get_assignment(path_name.at(i)));
+            uint64_t encoded_char = get_assignment(path_name.at(i));
+            if (encoded_char == numeric_limits<uint64_t>::max()) {
+                // this path name contains characters we've never seen before
+                encoded.clear();
+                break;
+            }
+            encoded.set(i, encoded_char);
         }
         return encoded;
     }

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1906,8 +1906,8 @@ namespace sglib {
         out << "\tlinks: " << format_memory(links_total) << endl;
         out << "\tsteps: " << format_memory(steps_total) << endl;
         out << "\tother: " << format_memory(other_total) << endl;
-        out << "\tdead paths: " << format_memory(dead_object_total)
-        out << "\texcess capacity: " << format_memory(path_excess_cap)
+        out << "\tdead paths: " << format_memory(dead_object_total) << endl;
+        out << "\texcess capacity: " << format_memory(path_excess_cap) << endl;
         
         grand_total += path_total;
         


### PR DESCRIPTION
I now store names internally in a bit-packed format, where chars from the path names are greedily encoded as small integers.