### PR TITLE
Improve PackedGraph memory usage for high path coverage graphs

### DIFF
--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -442,10 +442,10 @@ private:
         /// Linked list records that encode the oriented nodes of the path. Indexes are
         /// 1-based, with 0 used as a sentinel to indicate none further.
         /// {prev index, next index}
-        PagedVector links_iv;
+        RobustPagedVector links_iv;
         /// The traversal value is stored in a separate vector at the matching index.
         /// {ID|orientation (bit-packed)}
-        PagedVector steps_iv;
+        RobustPagedVector steps_iv;
         
         /// 1-based index of the head of the linked list in steps_iv.
         size_t head = 0;

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -433,6 +433,14 @@ private:
     /// Bit-vector that marks whether the path at the same index is circular
     PackedVector path_is_circular_iv;
     
+    /// The 1-based index of the head of the linked list in steps_iv of the path
+    /// with the same index in paths
+    PagedVector path_head_iv;
+    
+    /// The 1-based index of the tail of the linked list in steps_iv of the path
+    /// with the same index in paths
+    PackedVector path_tail_iv;
+    
     /*
      * A struct to package the data associated with a path through the graph.
      */
@@ -446,12 +454,6 @@ private:
         /// The traversal value is stored in a separate vector at the matching index.
         /// {ID|orientation (bit-packed)}
         RobustPagedVector steps_iv;
-        
-        /// 1-based index of the head of the linked list in steps_iv.
-        size_t head = 0;
-        
-        /// 1-based index of the tail of the linked list in steps_iv.
-        size_t tail = 0;
         
         /// The number of steps that have been deleted from the path
         uint64_t deleted_step_records = 0;

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -427,17 +427,17 @@ private:
     /// The length of the path's name for the path with the same index in paths
     PackedVector path_name_length_iv;
     
+    /// Bit-vector that marks whether the path at the same index has been deleted
+    PackedVector path_is_deleted_iv;
+    
+    /// Bit-vector that marks whether the path at the same index is circular
+    PackedVector path_is_circular_iv;
+    
     /*
      * A struct to package the data associated with a path through the graph.
      */
     struct PackedPath {
-        PackedPath(bool is_circular) : is_circular(is_circular), steps_iv(NARROW_PAGE_WIDTH), links_iv(NARROW_PAGE_WIDTH) {}
-        
-        /// Marks whether this path has been deleted
-        bool is_deleted = false;
-        
-        /// Marks whether this path is circular
-        bool is_circular = false;
+        PackedPath() : steps_iv(NARROW_PAGE_WIDTH), links_iv(NARROW_PAGE_WIDTH) {}
         
         /// Linked list records that encode the oriented nodes of the path. Indexes are
         /// 1-based, with 0 used as a sentinel to indicate none further.

--- a/include/sglib/packed_graph.hpp
+++ b/include/sglib/packed_graph.hpp
@@ -441,6 +441,9 @@ private:
     /// with the same index in paths
     PackedVector path_tail_iv;
     
+    /// The number of steps that have have deleted from the path at the same index
+    PackedVector path_deleted_steps_iv;
+    
     /*
      * A struct to package the data associated with a path through the graph.
      */

--- a/include/sglib/packed_structs.hpp
+++ b/include/sglib/packed_structs.hpp
@@ -185,7 +185,7 @@ private:
  * size.
  */
 class RobustPagedVector {
-    
+public:
     /// Construct and set page size (starts empty)
     RobustPagedVector(size_t page_size);
     
@@ -723,7 +723,7 @@ inline void RobustPagedVector::resize(const size_t& new_size) {
 inline void RobustPagedVector::reserve(const size_t& future_size) {
     if (future_size > latter_pages.page_width()) {
         first_page.reserve(latter_pages.page_width());
-        latter_pages.reserve(new_size - latter_pages.page_width());
+        latter_pages.reserve(future_size - latter_pages.page_width());
     }
     else {
         first_page.reserve(future_size);
@@ -735,7 +735,7 @@ inline size_t RobustPagedVector::size() const {
 }
 
 inline bool RobustPagedVector::empty() const {
-    return first_page.empty() && latter_pages.empty()
+    return first_page.empty() && latter_pages.empty();
 }
 
 inline void RobustPagedVector::clear() {

--- a/include/sglib/packed_structs.hpp
+++ b/include/sglib/packed_structs.hpp
@@ -180,6 +180,79 @@ private:
 };
 
 /*
+ * A dynamic integer vector with similar compression properties to the PagedVector,
+ * but better memory usage if the vector may be very small (relative to the page
+ * size.
+ */
+class RobustPagedVector {
+    
+    /// Construct and set page size (starts empty)
+    RobustPagedVector(size_t page_size);
+    
+    /// Construct from contents in a stream
+    RobustPagedVector(istream& in);
+    
+    /// Move constructor
+    RobustPagedVector(RobustPagedVector&& other) = default;
+    /// Move assignment operator
+    RobustPagedVector& operator=(RobustPagedVector&& other) = default;
+    
+    // Destructor
+    ~RobustPagedVector();
+    
+    /// Clear current contents and load from contents in a stream
+    void deserialize(istream& in);
+    
+    /// Output contents to a stream
+    void serialize(ostream& out) const;
+    
+    /// Set the i-th value
+    inline void set(const size_t& i, const uint64_t& value);
+    
+    /// Returns the i-th value
+    inline uint64_t get(const size_t& i) const;
+    
+    /// Add a value to the end
+    inline void append(const uint64_t& value);
+    
+    /// Remove the last value
+    inline void pop();
+    
+    /// Either shrink the vector or grow the vector to the new size. New
+    /// entries created by growing are filled with 0.
+    inline void resize(const size_t& new_size);
+    
+    /// If necessary, expand capacity so that the given number of entries can
+    /// be included in the vector without reallocating. Never shrinks capacity.
+    inline void reserve(const size_t& future_size);
+    
+    /// Returns the number of values
+    inline size_t size() const;
+    
+    /// Returns true if there are no entries and false otherwise
+    inline bool empty() const;
+    
+    /// Clears the backing vector
+    inline void clear();
+    
+    /// Returns the page width of the vector
+    inline size_t page_width() const;
+    
+    /// Reports the amount of memory consumed by this object in bytes
+    size_t memory_usage() const;
+    
+private:
+    
+    RobustPagedVector();
+    
+    /// The first page_size entries go in this vector
+    PackedVector first_page;
+    
+    /// All entries beyond page_size go in this vector
+    PagedVector latter_pages;
+};
+
+/*
  * A deque implementation that maintains integers in bit-compressed form, with the bit
  * width automatically adjusted to the entries.
  */
@@ -599,6 +672,81 @@ inline uint64_t PagedVector::from_diff(const uint64_t& diff, const uint64_t& anc
         return anchor + diff - diff / 5 - 1;
     }
 }
+    
+inline void RobustPagedVector::set(const size_t& i, const uint64_t& value) {
+    if (i < latter_pages.page_width()) {
+        first_page.set(i, value);
+    }
+    else {
+        latter_pages.set(i - latter_pages.page_width(), value);
+    }
+}
+
+inline uint64_t RobustPagedVector::get(const size_t& i) const {
+    if (i < latter_pages.page_width()) {
+        return first_page.get(i);
+    }
+    else {
+        return latter_pages.get(i - latter_pages.page_width());
+    }
+}
+
+inline void RobustPagedVector::append(const uint64_t& value) {
+    if (first_page.size() < latter_pages.page_width()) {
+        first_page.append(value);
+    }
+    else {
+        latter_pages.append(value);
+    }
+}
+
+inline void RobustPagedVector::pop() {
+    if (latter_pages.empty()) {
+        first_page.pop();
+    }
+    else {
+        latter_pages.pop();
+    }
+}
+
+inline void RobustPagedVector::resize(const size_t& new_size) {
+    if (new_size > latter_pages.page_width()) {
+        first_page.resize(latter_pages.page_width());
+        latter_pages.resize(new_size - latter_pages.page_width());
+    }
+    else {
+        first_page.resize(new_size);
+        latter_pages.clear();
+    }
+}
+
+inline void RobustPagedVector::reserve(const size_t& future_size) {
+    if (future_size > latter_pages.page_width()) {
+        first_page.reserve(latter_pages.page_width());
+        latter_pages.reserve(new_size - latter_pages.page_width());
+    }
+    else {
+        first_page.reserve(future_size);
+    }
+}
+
+inline size_t RobustPagedVector::size() const {
+    return first_page.size() + latter_pages.size();
+}
+
+inline bool RobustPagedVector::empty() const {
+    return first_page.empty() && latter_pages.empty()
+}
+
+inline void RobustPagedVector::clear() {
+    first_page.clear();
+    latter_pages.clear();
+}
+
+inline size_t RobustPagedVector::page_width() const {
+    return latter_pages.page_width();
+}
+    
 }
 
 

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1977,8 +1977,8 @@ namespace sglib {
             if (individual_paths) {
                 out << "\tdeleted paths (" << unused_path_ids.size() << ")" << endl;
                 out << "\t\tid: " << format_memory(0) << endl;
-                out << "\t\tlinks (" << link_length << "): " << format_memory(dead_links_total) << endl;
-                out << "\t\tsteps (" << step_length << "): " << format_memory(dead_steps_total) << endl;
+                out << "\t\tlinks: " << format_memory(dead_links_total) << endl;
+                out << "\t\tsteps: " << format_memory(dead_steps_total) << endl;
             }
         }
         
@@ -1998,8 +1998,8 @@ namespace sglib {
         out << "paths (" << path_id.size() << ") total: " << format_memory(path_total) << endl;
         out << "\tname: " << format_memory(name_total) << endl;
         out << "\tid: " << format_memory(id_total) << endl;
-        out << "\tlinks: " << format_memory(links_total) << endl;
-        out << "\tsteps: " << format_memory(steps_total) << endl;
+        out << "\tlinks (" <<  link_length << "): " << format_memory(links_total) << endl;
+        out << "\tsteps (" <<  step_length << "): " << format_memory(steps_total) << endl;
         out << "\tdead paths: " << format_memory(dead_object_total) << endl;
         out << "\tht excess capacity: " << format_memory(hash_table_excess_cap) << endl;
         out << "\tvec excess capacity: " << format_memory(vector_excess_cap) << endl;

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -52,7 +52,8 @@ namespace sglib {
         path_membership_next_iv(NARROW_PAGE_WIDTH),
         path_membership_offset_iv(NARROW_PAGE_WIDTH),
         path_membership_id_iv(WIDE_PAGE_WIDTH),
-        path_name_start_iv(NARROW_PAGE_WIDTH) {
+        path_name_start_iv(NARROW_PAGE_WIDTH),
+        path_head_iv(WIDE_PAGE_WIDTH) {
         
         // set pretty full load factors
         path_id.max_load_factor(0.5);
@@ -1731,7 +1732,7 @@ namespace sglib {
                 path_head_iv.set(path_idx, next_offset);
             }
             else if (step_offset == path_tail_iv.get(path_idx)) {
-                path_tail_iv.get(path_idx, prev_offset);
+                path_tail_iv.set(path_idx, prev_offset);
             }
             
             packed_path.deleted_step_records++;
@@ -1773,7 +1774,7 @@ namespace sglib {
             }
             else {
                 // place after the tail, since we're not putting it before anything
-                if (path_tail_iv.get(as_integer(path)) != 0) {
+                if (path_tail_iv.get(path_idx) != 0) {
                     // attach to the tail
                     uint64_t tail_next = get_step_next(packed_path, path_tail_iv.get(path_idx));
                     set_step_next(packed_path, path_tail_iv.get(path_idx), step_offset);
@@ -1985,7 +1986,6 @@ namespace sglib {
         
         out << "paths (" << path_id.size() << ") total: " << format_memory(path_total) << endl;
         out << "\tname: " << format_memory(name_total) << endl;
-        out << "\tlist ptrs: " << format_memory(list_ptr_total) << endl;
         out << "\tid: " << format_memory(id_total) << endl;
         out << "\tlinks: " << format_memory(links_total) << endl;
         out << "\tsteps: " << format_memory(steps_total) << endl;

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -965,7 +965,7 @@ namespace sglib {
         }
         path_is_circular_iv = move(new_path_is_circular_iv);
         
-        PackedVector new_path_head_iv;
+        PagedVector new_path_head_iv(path_head_iv.page_width());
         new_path_head_iv.reserve(paths.size());
         for (size_t i = 0; i < paths.size(); ++i) {
             new_path_head_iv.append(path_head_iv.get(i));

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1961,7 +1961,7 @@ namespace sglib {
             links_total += links_mem;
             steps_total += steps_mem;
             link_length += packed_path.links_iv.size();
-            step_length += packed_path.listeps_ivnks_iv.size();
+            step_length += packed_path.steps_iv.size();
         }
         
         size_t path_object_total = name_total + id_total + links_total + steps_total;

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -759,8 +759,8 @@ namespace sglib {
             if (path.head != 0) {
                 
                 // the path is non-empty, so we need to straighten it out and reallocate it
-                PagedVector new_steps_iv(path.steps_iv.page_width());
-                PagedVector new_links_iv(path.links_iv.page_width());
+                RobustPagedVector new_steps_iv(path.steps_iv.page_width());
+                RobustPagedVector new_links_iv(path.links_iv.page_width());
                 
                 // we will need to record the translation between path steps so we can update memberships later
                 PagedVector offset_translator(NARROW_PAGE_WIDTH);
@@ -861,8 +861,8 @@ namespace sglib {
             }
             else {
                 // the path is empty, so let's make sure it's not holding onto any capacity it doesn't need
-                path.links_iv = PagedVector(path.links_iv.page_width());
-                path.steps_iv = PagedVector(path.steps_iv.page_width());
+                path.links_iv = RobustPagedVector(path.links_iv.page_width());
+                path.steps_iv = RobustPagedVector(path.steps_iv.page_width());
             }
             
             path.deleted_step_records = 0;

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1998,7 +1998,6 @@ namespace sglib {
         out << "\tid: " << format_memory(id_total) << endl;
         out << "\tlinks: " << format_memory(links_total) << endl;
         out << "\tsteps: " << format_memory(steps_total) << endl;
-        out << "\tother: " << format_memory(other_total) << endl;
         out << "\tdead paths: " << format_memory(dead_object_total) << endl;
         out << "\texcess capacity: " << format_memory(path_excess_cap) << endl;
         

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1940,7 +1940,7 @@ namespace sglib {
         if (individual_paths) {
             out << "individual paths:" << endl;
         }
-        
+        size_t link_length = 0, step_length = 0;
         size_t name_total = 0, id_total = 0, links_total = 0, steps_total = 0;
         for (const auto& path_name : names) {
             auto it = path_id.find(encode_path_name(path_name));
@@ -1953,13 +1953,15 @@ namespace sglib {
                 out << "\t" << path_name << ":" << endl;
                 out << "\t\tname: " << format_memory(path_name_mem) << endl;
                 out << "\t\tid: " << format_memory(path_id_mem) << endl;
-                out << "\t\tlinks: " << format_memory(links_mem) << endl;
-                out << "\t\tsteps: " << format_memory(steps_mem) << endl;
+                out << "\t\tlinks (" << packed_path.links_iv.size() << "): " << format_memory(links_mem) << endl;
+                out << "\t\tsteps (" << packed_path.steps_iv.size() << "): " << format_memory(steps_mem) << endl;
             }
             name_total += path_name_mem;
             id_total += path_id_mem;
             links_total += links_mem;
             steps_total += steps_mem;
+            link_length += packed_path.links_iv.size();
+            step_length += packed_path.listeps_ivnks_iv.size();
         }
         
         size_t path_object_total = name_total + id_total + links_total + steps_total;
@@ -1975,8 +1977,8 @@ namespace sglib {
             if (individual_paths) {
                 out << "\tdeleted paths (" << unused_path_ids.size() << ")" << endl;
                 out << "\t\tid: " << format_memory(0) << endl;
-                out << "\t\tlinks: " << format_memory(dead_links_total) << endl;
-                out << "\t\tsteps: " << format_memory(dead_steps_total) << endl;
+                out << "\t\tlinks (" << link_length << "): " << format_memory(dead_links_total) << endl;
+                out << "\t\tsteps (" << step_length << "): " << format_memory(dead_steps_total) << endl;
             }
         }
         

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -138,6 +138,7 @@ namespace sglib {
         path_tail_iv.deserialize(in);
         path_deleted_steps_iv.deserialize(in);
         
+        paths.reserve(path_name_start_iv.size());
         for (size_t i = 0; i < path_name_start_iv.size(); i++) {
             paths.emplace_back();
             PackedPath& path = paths.back();

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1991,7 +1991,7 @@ namespace sglib {
         vector_excess_cap += (paths.capacity() - paths.size()) * sizeof(decltype(paths)::value_type);
         vector_excess_cap += sizeof(paths);
         
-        size_t path_total = path_object_total + dead_object_total + path_excess_cap;
+        size_t path_total = path_object_total + dead_object_total + vector_excess_cap + hash_table_excess_cap;
         
         out << "paths (" << path_id.size() << ") total: " << format_memory(path_total) << endl;
         out << "\tname: " << format_memory(name_total) << endl;

--- a/src/packed_graph.cpp
+++ b/src/packed_graph.cpp
@@ -1982,14 +1982,14 @@ namespace sglib {
         
         size_t dead_object_total = dead_links_total + dead_steps_total;
         
-        size_t path_excess_cap = 0;
-        // add the local size and extra capacity in the path id hash table
-        path_excess_cap += (path_id.bucket_count() - path_id.size()) * sizeof(decltype(path_id)::key_type);
-        path_excess_cap += (path_id.bucket_count() - path_id.size()) * sizeof(decltype(path_id)::value_type);
-        path_excess_cap += sizeof(path_id);
-        // add the local size and extra capacity in the path vector
-        path_excess_cap += (paths.capacity() - paths.size()) * sizeof(decltype(paths)::value_type);
-        path_excess_cap += sizeof(paths);
+        size_t hash_table_excess_cap = 0;
+        hash_table_excess_cap += (path_id.bucket_count() - path_id.size()) * sizeof(decltype(path_id)::key_type);
+        hash_table_excess_cap += (path_id.bucket_count() - path_id.size()) * sizeof(decltype(path_id)::value_type);
+        hash_table_excess_cap += sizeof(path_id);
+        
+        size_t vector_excess_cap = 0;
+        vector_excess_cap += (paths.capacity() - paths.size()) * sizeof(decltype(paths)::value_type);
+        vector_excess_cap += sizeof(paths);
         
         size_t path_total = path_object_total + dead_object_total + path_excess_cap;
         
@@ -1999,7 +1999,8 @@ namespace sglib {
         out << "\tlinks: " << format_memory(links_total) << endl;
         out << "\tsteps: " << format_memory(steps_total) << endl;
         out << "\tdead paths: " << format_memory(dead_object_total) << endl;
-        out << "\texcess capacity: " << format_memory(path_excess_cap) << endl;
+        out << "\tht excess capacity: " << format_memory(hash_table_excess_cap) << endl;
+        out << "\tvec excess capacity: " << format_memory(vector_excess_cap) << endl;
         
         grand_total += path_total;
         

--- a/src/packed_structs.cpp
+++ b/src/packed_structs.cpp
@@ -107,4 +107,33 @@ size_t PackedDeque::memory_usage() const {
     return sizeof(begin_idx) + sizeof(filled) + vec.memory_usage();
 }
 
+RobustPagedVector::RobustPagedVector(size_t page_size) : latter_pages(page_size) {
+    // Nothing to do
+}
+
+RobustPagedVector::RobustPagedVector() : latter_pages(1) {
+    // Nothing to do
+}
+
+RobustPagedVector::RobustPagedVector(istream& in) {
+    deserialize(in);
+}
+
+RobustPagedVector::~RobustPagedVector() {
+    
+}
+
+void RobustPagedVector::deserialize(istream& in) {
+    first_page.deserialize(in);
+    latter_pages.deserialize(in);
+}
+
+void RobustPagedVector::serialize(ostream& out) const {
+    first_page.serialize(out);
+    latter_pages.serialize(out);
+}
+
+size_t RobustPagedVector::memory_usage() const {
+    return first_page.memory_usage() + latter_pages.memory_usage();
+}
 }

--- a/src/packed_structs.cpp
+++ b/src/packed_structs.cpp
@@ -111,11 +111,12 @@ RobustPagedVector::RobustPagedVector(size_t page_size) : latter_pages(page_size)
     // Nothing to do
 }
 
-RobustPagedVector::RobustPagedVector() : latter_pages(1) {
+RobustPagedVector::RobustPagedVector() : latter_pages(64) {
     // Nothing to do
 }
 
-RobustPagedVector::RobustPagedVector(istream& in) {
+
+RobustPagedVector::RobustPagedVector(istream& in) : latter_pages(64) { // dummy page size
     deserialize(in);
 }
 


### PR DESCRIPTION
I didn't really design PackedGraph for graphs with large numbers of paths, so it wasn't performing particularly well on them. I've moved a lot of uncompressed, per-path variables into compressed vectors. I've also made a new packed data structure that can compress locally correlated entries, but avoids some of the large constant overhead of the PagedVector (so that it remains efficient for large numbers of short paths in addition to small numbers of long paths).